### PR TITLE
Фикс бага экспорта с добавлением data-узлов переходов при отсутствии действий

### DIFF
--- a/demos/arduino-blinker.graphml
+++ b/demos/arduino-blinker.graphml
@@ -71,7 +71,7 @@ y/ 13
         <data key="dVertex">initial</data>
     </node>
 
-   <node id="diod1">
+    <node id="diod1">
         <data key="dName">Включен</data>
         <data key="dData">entry propagate/
 LED1.on()
@@ -105,7 +105,9 @@ timer1.start(1000)
 y/ 13
         </data>
     </node>
-    <edge id="init-edge" source="init" target="diod1"/>
+    <edge id="init-edge" source="init" target="diod1"> 
+        <data key="dColor">#F29727</data>
+    </edge>
     <edge id="edge0" source="coreMeta" target="ctimer1"> 
         <data key="dPivot"/>
     </edge>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kruzhok-team/cyberiadaml-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kruzhok-team/cyberiadaml-js",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@types/jest": "^29.5.12",

--- a/src/buildFunctions.ts
+++ b/src/buildFunctions.ts
@@ -309,33 +309,34 @@ function getEdges(
       '@id': transition.id,
       '@source': transition.source,
       '@target': transition.target,
+      data: []
     };
     if (transition.actions.length !== 0) {
-      edge.data = [
+      edge.data.push(
         {
           '@key': 'dData',
           content: textMode
             ? (transition.actions as string)
             : serializeActions(transition.actions as CGMLTransitionAction[]),
         },
-      ];
+      )
     }
     if (transition.color !== undefined) {
-      edge.data?.push({
+      edge.data.push({
         '@key': 'dColor',
         content: transition.color,
       });
     }
     if (transition.position !== undefined) {
-      edge.data?.push(getGeometryDataNode(transition.position));
+      edge.data.push(getGeometryDataNode(transition.position));
     }
 
     if (transition.labelPosition) {
-      edge.data?.push(getLabelPositionNode(transition.labelPosition));
+      edge.data.push(getLabelPositionNode(transition.labelPosition));
     }
 
     for (const dataNode of transition.unsupportedDataNodes) {
-      edge.data?.push({
+      edge.data.push({
         '@key': dataNode.key,
         content: dataNode.content,
       });

--- a/src/import.test.ts
+++ b/src/import.test.ts
@@ -1,5 +1,6 @@
-import { parseCGML, parseTextCGML } from './import';
 import { readFileSync } from 'fs';
+
+import { parseCGML, parseTextCGML } from './import';
 import { CGMLElements, CGMLTextElements } from './types/import';
 
 test('test parsing arduino', () => {
@@ -54,6 +55,7 @@ test('test parsing arduino', () => {
           'init-edge': {
             id: 'init-edge',
             source: 'init',
+            color: '#F29727',
             target: 'diod1',
             actions: [],
             pivot: undefined,
@@ -1018,6 +1020,7 @@ timer1.start(1000)`,
         transitions: {
           'init-edge': {
             id: 'init-edge',
+            color: '#F29727',
             source: 'init',
             target: 'diod1',
             actions: '',

--- a/src/types/export.ts
+++ b/src/types/export.ts
@@ -30,7 +30,7 @@ export type ExportEdge = {
   '@id': string;
   '@source': string;
   '@target': string;
-  data?: Array<ExportDataNode>;
+  data: Array<ExportDataNode>;
 };
 
 export type ExportNote = {


### PR DESCRIPTION
Если действий на переходе нет, то не добавлялись другие data-узлы, связанные с цветом, позицией, и т.д.
