### PR TITLE
Мета-информация у каждой машины состояний

### DIFF
--- a/demos/two-blinkers.graphml
+++ b/demos/two-blinkers.graphml
@@ -124,6 +124,21 @@ timer1.start(1000)
 
 <graph id="O" edgedefault="directed">
     <data key="dStateMachine"/>
+        <node id="coreMeta">
+        <data key="dNote">formal</data>
+        <data key="dName">CGML_META</data>
+        <data key="dData">platform/ ArduinoUno
+
+standardVersion/ 1.0
+
+name/ Arduino Blinker
+
+author/ Lapki IDE TEAM
+
+description/ Включение и выключение лампочки по таймеру
+
+        </data>
+    </node>
     <node id="cLED1">
         <data key="dNote">formal</data>
         <data key="dName"> CGML_COMPONENT </data>

--- a/src/buildFunctions.ts
+++ b/src/buildFunctions.ts
@@ -424,12 +424,12 @@ function getGraphs(elements: CGMLElements | CGMLTextElements, textMode: boolean)
       ],
       edge: [...getEdges(stateMachine.transitions, textMode)],
     };
+    graph.node = [
+      getMetaNode(stateMachine.platform, stateMachine.meta, stateMachine.standardVersion),
+      ...graph.node,
+    ];
     graphs.push(graph);
   }
-  graphs[0].node = [
-    getMetaNode(elements.platform, elements.meta, elements.standardVersion),
-    ...graphs[0].node,
-  ];
   return graphs;
 }
 

--- a/src/import.test.ts
+++ b/src/import.test.ts
@@ -167,17 +167,17 @@ y/ 13`,
         terminates: {},
         finals: {},
         unknownVertexes: {},
+        standardVersion: '1.0',
+        platform: 'ArduinoUno',
+        meta: {
+          values: {
+            name: 'Arduino Blinker',
+            author: 'Lapki IDE TEAM',
+            description: 'Включение и выключение лампочки по таймеру',
+          },
+          id: 'coreMeta',
+        },
       },
-    },
-    standardVersion: '1.0',
-    platform: 'ArduinoUno',
-    meta: {
-      values: {
-        name: 'Arduino Blinker',
-        author: 'Lapki IDE TEAM',
-        description: 'Включение и выключение лампочки по таймеру',
-      },
-      id: 'coreMeta',
     },
     format: 'Cyberiada-GraphML-1.0',
     keys: [
@@ -257,6 +257,16 @@ test('test parsing Arduino multidocument', () => {
   const predicted: CGMLElements = {
     stateMachines: {
       G: {
+        standardVersion: '1.0',
+        platform: 'ArduinoUno',
+        meta: {
+          values: {
+            name: 'Arduino Blinker',
+            author: 'Lapki IDE TEAM',
+            description: 'Включение и выключение лампочки по таймеру',
+          },
+          id: 'coreMeta',
+        },
         states: {
           diod1: {
             name: 'Включен',
@@ -400,6 +410,16 @@ test('test parsing Arduino multidocument', () => {
         unknownVertexes: {},
       },
       O: {
+        standardVersion: '1.0',
+        platform: 'ArduinoUno',
+        meta: {
+          values: {
+            name: 'Arduino Blinker',
+            author: 'Lapki IDE TEAM',
+            description: 'Включение и выключение лампочки по таймеру',
+          },
+          id: 'coreMeta',
+        },
         states: {
           diod1: {
             name: 'Включен',
@@ -543,16 +563,6 @@ test('test parsing Arduino multidocument', () => {
         unknownVertexes: {},
       },
     },
-    standardVersion: '1.0',
-    platform: 'ArduinoUno',
-    meta: {
-      values: {
-        name: 'Arduino Blinker',
-        author: 'Lapki IDE TEAM',
-        description: 'Включение и выключение лампочки по таймеру',
-      },
-      id: 'coreMeta',
-    },
     format: 'Cyberiada-GraphML-1.0',
     keys: [
       {
@@ -631,6 +641,19 @@ test('test parsing bearloga', () => {
   const predicted: CGMLElements = {
     stateMachines: {
       G: {
+        platform: 'BearsTowerDefence',
+        meta: {
+          values: {
+            name: 'Автобортник',
+            author: 'Матросов В.М.',
+            contact: 'matrosov@mail.ru',
+            description:
+              'Пример описания схемы, \nкоторый может быть многострочным, потому что так удобнее',
+            target: 'Autoborder',
+          },
+          id: 'nMeta',
+        },
+        standardVersion: '1.0',
         states: {
           'n0::n1': {
             name: 'Сближение',
@@ -843,19 +866,6 @@ test('test parsing bearloga', () => {
         unknownVertexes: {},
       },
     },
-    platform: 'BearsTowerDefence',
-    meta: {
-      values: {
-        name: 'Автобортник',
-        author: 'Матросов В.М.',
-        contact: 'matrosov@mail.ru',
-        description:
-          'Пример описания схемы, \nкоторый может быть многострочным, потому что так удобнее',
-        target: 'Autoborder',
-      },
-      id: 'nMeta',
-    },
-    standardVersion: '1.0',
     format: 'Cyberiada-GraphML-1.0',
     keys: [
       {
@@ -1116,17 +1126,17 @@ y/ 13`,
         terminates: {},
         finals: {},
         unknownVertexes: {},
+        standardVersion: '1.0',
+        platform: 'ArduinoUno',
+        meta: {
+          values: {
+            name: 'Arduino Blinker',
+            author: 'Lapki IDE TEAM',
+            description: 'Включение и выключение лампочки по таймеру',
+          },
+          id: 'coreMeta',
+        },
       },
-    },
-    standardVersion: '1.0',
-    platform: 'ArduinoUno',
-    meta: {
-      values: {
-        name: 'Arduino Blinker',
-        author: 'Lapki IDE TEAM',
-        description: 'Включение и выключение лампочки по таймеру',
-      },
-      id: 'coreMeta',
     },
     format: 'Cyberiada-GraphML-1.0',
     keys: [
@@ -1411,19 +1421,19 @@ test('test parse-export-parse cycle, state nested >2', () => {
         choices: {},
         finals: {},
         unknownVertexes: {},
+        platform: 'ArduinoUno',
+        meta: {
+          values: {
+            name: 'Arduino Blinker',
+            author: 'Lapki IDE TEAM',
+            description: 'Включение и выключение лампочки по таймеру',
+            platformVersion: '1.0',
+          },
+          id: 'coreMeta',
+        },
+        standardVersion: '1.0',
       },
     },
-    platform: 'ArduinoUno',
-    meta: {
-      values: {
-        name: 'Arduino Blinker',
-        author: 'Lapki IDE TEAM',
-        description: 'Включение и выключение лампочки по таймеру',
-        platformVersion: '1.0',
-      },
-      id: 'coreMeta',
-    },
-    standardVersion: '1.0',
     format: 'Cyberiada-GraphML-1.0',
     keys: [
       {

--- a/src/import.ts
+++ b/src/import.ts
@@ -43,16 +43,16 @@ export function parseCGML(graphml: string): CGMLElements {
     resetComponentOrder();
     const stateMachine = processGraph(elements, emptyCGMLStateMachine(), graph, false);
     stateMachine.name = getStateMachineName(graph);
+    stateMachine.platform = stateMachine.meta.values['platform'];
+    stateMachine.standardVersion = stateMachine.meta.values['standardVersion'];
     stateMachine.transitions = removeComponentsTransitions(
       stateMachine.transitions,
-      elements.meta.id,
+      stateMachine.meta.id,
     ) as Record<string, CGMLTransition>;
+    delete stateMachine.meta.values['platform'];
+    delete stateMachine.meta.values['standardVersion'];
     elements.stateMachines[graph.id] = stateMachine as CGMLStateMachine;
   }
-  elements.platform = elements.meta.values['platform'];
-  elements.standardVersion = elements.meta.values['standardVersion'];
-  delete elements.meta.values['platform'];
-  delete elements.meta.values['standardVersion'];
   return elements;
 }
 
@@ -75,15 +75,15 @@ export function parseTextCGML(graphml: string): CGMLTextElements {
     resetComponentOrder();
     const stateMachine = processGraph(elements, emptyCGMLStateMachine(), graph, true);
     stateMachine.name = getStateMachineName(graph);
+    stateMachine.platform = stateMachine.meta.values['platform'];
+    stateMachine.standardVersion = stateMachine.meta.values['standardVersion'];
     stateMachine.transitions = removeComponentsTransitions(
       stateMachine.transitions,
-      elements.meta.id,
+      stateMachine.meta.id,
     ) as Record<string, CGMLTransition>;
     elements.stateMachines[graph.id] = stateMachine as CGMLTextStateMachine;
+    delete stateMachine.meta.values['platform'];
+    delete stateMachine.meta.values['standardVersion'];
   }
-  elements.platform = elements.meta.values['platform'];
-  elements.standardVersion = elements.meta.values['standardVersion'];
-  delete elements.meta.values['platform'];
-  delete elements.meta.values['standardVersion'];
   return elements;
 }

--- a/src/parseFunctions.ts
+++ b/src/parseFunctions.ts
@@ -500,11 +500,14 @@ export function processGraph(
         componentOrder += 1;
         break;
       case 'CGML_META':
-        if (!(Object.values(elements.meta.values).length === 0) && !(elements.meta.id === '')) {
+        if (
+          !(Object.values(stateMachine.meta.values).length === 0) &&
+          !(stateMachine.meta.id === '')
+        ) {
           throw new Error('Double meta-node!');
         }
-        elements.meta.values = parseMeta(note.text);
-        elements.meta.id = node.id;
+        stateMachine.meta.values = parseMeta(note.text);
+        stateMachine.meta.id = node.id;
         break;
       default:
         throw new Error(

--- a/src/types/import.ts
+++ b/src/types/import.ts
@@ -91,24 +91,21 @@ export type CGMLComponent = {
 
 export type CGMLElements = {
   stateMachines: { [id: string]: CGMLStateMachine };
-  meta: CGMLMeta;
-  standardVersion: string;
-  platform: string;
   format: string;
   keys: Array<CGMLKeyNode>;
 };
 
 export type CGMLTextElements = {
   stateMachines: { [id: string]: CGMLTextStateMachine };
-  meta: CGMLMeta;
-  standardVersion: string;
-  platform: string;
   format: string;
   keys: Array<CGMLKeyNode>;
 };
 
 export type CGMLStateMachine = {
   name?: string;
+  meta: CGMLMeta;
+  standardVersion: string;
+  platform: string;
   states: { [id: string]: CGMLState };
   transitions: Record<string, CGMLTransition>;
   components: { [id: string]: CGMLComponent };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,12 @@ export function toArray<Type>(value: Type | Array<Type>): Array<Type> {
 
 export function emptyCGMLStateMachine(): CGMLStateMachine {
   return {
+    platform: '',
+    standardVersion: '',
+    meta: {
+      id: '',
+      values: {},
+    },
     states: {},
     transitions: {},
     components: {},
@@ -44,12 +50,6 @@ export function emptyCGMLStateMachine(): CGMLStateMachine {
 export function createEmptyTextElements(): CGMLTextElements {
   return {
     stateMachines: {},
-    platform: '',
-    meta: {
-      values: {},
-      id: '',
-    },
-    standardVersion: '',
     format: '',
     keys: [],
   };
@@ -58,12 +58,6 @@ export function createEmptyTextElements(): CGMLTextElements {
 export function createEmptyElements(): CGMLElements {
   return {
     stateMachines: {},
-    platform: '',
-    meta: {
-      values: {},
-      id: '',
-    },
-    standardVersion: '',
     format: '',
     keys: [],
   };


### PR DESCRIPTION
Раньше meta бралась у первой машины состояний в схеме, meta-узлы в других машинах состояний вызывали ошибку. Теперь мета-информация привязывается к машине состояний, а не к документу в целом